### PR TITLE
item geometry constraints

### DIFF
--- a/polygonitem.cpp
+++ b/polygonitem.cpp
@@ -216,8 +216,11 @@ void PolygonItem::onManualResizeProgress(GripPoint* gp, const QPointF& from, con
         return;
     }
 
-    const auto grips = m_gripPointsHandler->gripPoints();
-    updatePoint(grips.indexOf(gp), to);
+    if(scene() && scene()->sceneRect().contains(to))
+    {
+        const auto grips = m_gripPointsHandler->gripPoints();
+        updatePoint(grips.indexOf(gp), to);
+    }
 }
 
 

--- a/polygonitem.cpp
+++ b/polygonitem.cpp
@@ -166,47 +166,22 @@ void PolygonItem::onManualMoveProgress(GripPoint* gp, const QPointF& from, const
 {
     Q_UNUSED(gp);
 
-    // It's a place to check if the current item is movable,
-    // validate the desired movement, check for collisions or whatever,
-    // and apply it to GUI, if the movement is acceptable
-
-    //    const QPointF shift = to - from;
-    //    if (!shift.isNull())
-    //    {
-    //        moveBy(shift.x(), shift.y());
-    //        updateBoundingRect();
-    //    }
-
-    const QPointF shift = to - from;
+    QPointF shift = to - from;
     if (!shift.isNull())
     {
-        moveBy(shift.x(), shift.y());
-
-        // get the new moved position
-        QPointF newPos = pos();
-
-        // restricts the item from moving outside the
-        // image
-        if (newPos.x() < 0)
+        if(auto scene = this->scene())
         {
-            newPos.setX(0);
-        }
-        else if (newPos.x() + boundingRect().right() > scene()->width())
-        {
-            newPos.setX(scene()->width() - boundingRect().width());
-        }
+            const QRectF& sceneRect = scene->sceneRect();
+            for( const QPointF& currentPoint : localPoints())
+            {
+                const QPointF& upcomingPoint = currentPoint + shift;
+                if(!sceneRect.contains(upcomingPoint))
+                    return;
+            }
 
-        if (newPos.y() < 0)
-        {
-            newPos.setY(0);
+            moveBy(shift.x(),shift.y());
+            updateBoundingRect();
         }
-        else if (newPos.y() + boundingRect().bottom() > scene()->height())
-        {
-            newPos.setY(scene()->height() - boundingRect().height());
-        }
-
-        setPos(newPos);
-        updateBoundingRect();
     }
 }
 

--- a/rectangleitem.cpp
+++ b/rectangleitem.cpp
@@ -110,53 +110,33 @@ void RectangleItem::onManualMoveStart(GripPoint* gp, const QPointF& at)
 
 }
 
-
-
 void RectangleItem::onManualMoveProgress(GripPoint* gp, const QPointF& from, const QPointF& to)
 {
     Q_UNUSED(gp);
 
-    // It's a place to check if the current item is movable,
-    // validate the desired movement, check for collisions or whatever,
-    // and apply it to GUI, if the movement is acceptable
-
-    //    QPointF shift = to - from;
-    //    if (!shift.isNull())
-    //    {
-    //        moveBy(shift.x(), shift.y());
-    //        updateBoundingRect();
-    //    }
-
-    const QPointF shift = to - from;
+    QPointF shift = to - from;
     if (!shift.isNull())
     {
-        moveBy(shift.x(), shift.y());
-
-        // get the new moved position
-        QPointF newPos = pos();
-
-        // restricts the item from moving outside the
-        // image
-        if (newPos.x() < 0)
+        const QRectF& upcomingRect = sceneBoundingRect().translated(shift);
+        if(auto scene = this->scene())
         {
-            newPos.setX(0);
-        }
-        else if (newPos.x() + boundingRect().right() > scene()->width())
-        {
-            newPos.setX(scene()->width() - boundingRect().width());
-        }
+            const QRectF& sceneRect = scene->sceneRect();
+            if(!sceneRect.contains(upcomingRect))
+            {
+                if(upcomingRect.right() > sceneRect.right())
+                    shift.rx() += sceneRect.right()-upcomingRect.right();
+                else if(upcomingRect.left() < sceneRect.left())
+                    shift.rx() -= (upcomingRect.left()-sceneRect.left());
 
-        if (newPos.y() < 0)
-        {
-            newPos.setY(0);
-        }
-        else if (newPos.y() + boundingRect().bottom() > scene()->height())
-        {
-            newPos.setY(scene()->height() - boundingRect().height());
-        }
+                if(upcomingRect.top() < sceneRect.top())
+                    shift.ry() += sceneRect.top() - upcomingRect.top();
+                else if(upcomingRect.bottom() > sceneRect.bottom())
+                    shift.ry() -= upcomingRect.bottom() - sceneRect.bottom();
+            }
 
-        setPos(newPos);
-        updateBoundingRect();
+            moveBy(shift.x(), shift.y());
+            updateBoundingRect();
+        }
     }
 }
 

--- a/rectangleitem.cpp
+++ b/rectangleitem.cpp
@@ -171,45 +171,58 @@ void RectangleItem::onManualResizeProgress(GripPoint* gp, const QPointF& from, c
         return;
     }
 
+    QRectF upcomingRect(m_rect);
     switch(gp->location())
     {
         case GripPoint::Top:
-            m_rect.setTop(mapFromScene(to).y());
+            upcomingRect.setTop(mapFromScene(to).y());
             break;
 
         case GripPoint::Right:
-            m_rect.setRight(mapFromScene(to).x());
+            upcomingRect.setRight(mapFromScene(to).x());
             break;
 
         case GripPoint::Bottom:
-            m_rect.setBottom(mapFromScene(to).y());
+            upcomingRect.setBottom(mapFromScene(to).y());
             break;
 
         case GripPoint::Left:
-            m_rect.setLeft(mapFromScene(to).x());
+            upcomingRect.setLeft(mapFromScene(to).x());
             break;
 
         case GripPoint::TopLeft:
-            m_rect.setTopLeft(mapFromScene(to));
+            upcomingRect.setTopLeft(mapFromScene(to));
             break;
 
         case GripPoint::TopRight:
-            m_rect.setTopRight(mapFromScene(to));
+            upcomingRect.setTopRight(mapFromScene(to));
             break;
 
         case GripPoint::BottomRight:
-            m_rect.setBottomRight(mapFromScene(to));
+            upcomingRect.setBottomRight(mapFromScene(to));
             break;
 
         case GripPoint::BottomLeft:
-            m_rect.setBottomLeft(mapFromScene(to));
+            upcomingRect.setBottomLeft(mapFromScene(to));
             break;
 
         default:
             break;
     }
 
-    updateRect(m_rect);
+
+    if(auto scene = this->scene())
+    {
+        const QRectF& sceneRect = scene->sceneRect();
+        QRectF upcomingRectScene = mapToScene(upcomingRect).boundingRect();
+        if(!sceneRect.contains(upcomingRectScene))
+        {
+            upcomingRectScene = sceneRect.intersected(upcomingRectScene);
+            upcomingRect = mapFromScene(upcomingRectScene).boundingRect();
+        }
+    }
+
+    updateRect(upcomingRect);
 }
 
 


### PR DESCRIPTION
Items (PolygonItem, RectangleItem) movement/resizing forced to fit within the scene's rectangle.
For the rectangle item, if an attempt to move/resize results in exceeding the allowed area, the snapping is implemented — the nearest acceptable values used.
The same case for polygon just ignored (no geometry change performed at all).

Note: 
While detecting is it allowed movement or not, try to avoid calls to things like moveBy/setPos, when possible. These involve QGraphicScene internals, so if you moved an item and then detected that it exceeds the allowed area and moving it back to the initial position — there are two redundant calls to the scene/rendering/whatever. Considering the nowadays hardware and the scene size it's not a big deal, of course. But if you can avoid a pointless action — do avoid it :)